### PR TITLE
ENG-2398/ENG-2399 Protect all the configuration variables from EOL corruption

### DIFF
--- a/bin/mod/ent-ecr
+++ b/bin/mod/ent-ecr
@@ -61,7 +61,7 @@ RUN() {
       ;;
     "install-status") #H: shows the uninstall status of the bundle
       ecr-prepare-action INGRESS_URL TOKEN
-      mybundlemybundleecr-bundle-action "" "GET" "install" "$INGRESS_URL" "$TOKEN" "$@"
+      ecr-bundle-action "" "GET" "install" "$INGRESS_URL" "$TOKEN" "$@"
       ;;
     "uninstall-status") #H: shows the uninstall status of the bundle
       ecr-prepare-action INGRESS_URL TOKEN

--- a/s/utils.sh
+++ b/s/utils.sh
@@ -99,6 +99,8 @@ reload_cfg() {
     [[ "$var" =~ ^# ]] && continue
     if assert_ext_ic_id_with_arr "CFGVAR" "$var" "silent"; then
       printf -v sanitized "%q" "$value"
+      sanitized="${sanitized/\\\\r/}"
+      sanitized="${sanitized/\\\\n/}"
       eval "$var"="$sanitized"
     else
       _log_e 0 "Skipped illegal var name $var"


### PR DESCRIPTION
fixes ENG-2398 "ent prj install" sometimes doesn't work in windows